### PR TITLE
Clean up code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,37 @@
 [[package]]
+name = "widestring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "xladd"
 version = "0.1.0"
+dependencies = [
+ "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[metadata]
+"checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["Marcus Rainbow"]
 
 [dependencies]
+winapi = { version = "0.3.5", features = ["winuser", "libloaderapi", "debugapi"] }
+widestring = "0.4.0"

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,0 +1,99 @@
+//! Entry point code for xladd, based on the sample C++ code
+//! supplied with the Microsoft Excel12 SDK
+
+use std::ptr;
+use std::mem;
+use xlcall::{LPXLOPER12, XLOPER12, xlretFailed, xlFree};
+use variant::Variant;
+use winapi::um::libloaderapi::{GetModuleHandleW, GetProcAddress};
+use winapi::shared::minwindef::HMODULE;
+use widestring::U16CString;
+use std::ffi::CStr;
+
+const EXCEL12ENTRYPT: &[u8] = b"MdCallBack12\0";
+const XLCALL32DLL: &str = "XLCall32";
+const XLCALL32ENTRYPT: &[u8] = b"GetExcel12EntryPt\0";
+type EXCEL12PROC = extern "stdcall" fn(
+    xlfn: ::std::os::raw::c_int, 
+    count: ::std::os::raw::c_int,
+    rgpxloper12: *const LPXLOPER12,
+    xloper12res: LPXLOPER12) -> ::std::os::raw::c_int;
+type FNGETEXCEL12ENTRYPT = extern "stdcall" fn() -> usize;
+
+static mut XLCALL_HMODULE: HMODULE = ptr::null_mut();
+static mut PEXCEL12: usize = 0;
+
+/// Call into Excel, passing a function number as defined in xlcall and a slice
+/// of Variant, and returning a Variant. To find out the number and type of
+/// parameters and the expected result, please consult the Excel SDK documentation.
+/// 
+/// Note that this is a slightly inefficient call, in that it allocates a vector
+/// of pointers. For example, if you have a single argument, it is faster to invoke
+/// the single arg version.
+pub fn excel12(xlfn: u32, opers: &mut [Variant]) -> Variant {
+    let mut result = Variant::new();
+    let mut args: Vec<LPXLOPER12> = Vec::with_capacity(opers.len());    
+    for oper in opers.iter_mut() {
+        args.push(oper.as_mut_xloper());
+    }
+    excel12v(xlfn as i32, result.as_mut_xloper(), &mut args);
+    result
+}
+
+pub fn excel12_1(xlfn: u32, mut oper: Variant) -> Variant {
+    let mut result = Variant::new();
+    excel12v(xlfn as i32, result.as_mut_xloper(), &[oper.as_mut_xloper()]);
+    result
+}
+
+fn fetch_excel12_entry_pt() {
+
+    unsafe {
+        if XLCALL_HMODULE.is_null() {
+            let wcstr = U16CString::from_str(XLCALL32DLL).unwrap();
+            XLCALL_HMODULE = GetModuleHandleW(wcstr.as_ptr());
+            if !XLCALL_HMODULE.is_null() {
+                let cstr = CStr::from_bytes_with_nul(XLCALL32ENTRYPT).unwrap();
+                let entry_pt: usize = GetProcAddress(XLCALL_HMODULE, cstr.as_ptr()) as usize;
+                if entry_pt != 0 {
+                    PEXCEL12 = mem::transmute::<usize, FNGETEXCEL12ENTRYPT>(entry_pt)();
+                }
+            }
+        }
+
+        if PEXCEL12 == 0 {
+            XLCALL_HMODULE = GetModuleHandleW(ptr::null());
+            if !XLCALL_HMODULE.is_null() {
+                let cstr = CStr::from_bytes_with_nul(EXCEL12ENTRYPT).unwrap();
+
+                PEXCEL12 = GetProcAddress(XLCALL_HMODULE, cstr.as_ptr()) as usize;
+            }
+        }
+    }
+}
+
+pub fn excel12v(xlfn: i32, oper_res: &mut XLOPER12, opers: &[LPXLOPER12]) -> i32 {
+	fetch_excel12_entry_pt();
+
+    unsafe {
+        if PEXCEL12 == 0 {
+            xlretFailed as i32
+        } else {
+            let p = opers.as_ptr();
+            let len = opers.len();
+            mem::transmute::<usize, EXCEL12PROC>(PEXCEL12)(xlfn, len as i32, p, oper_res)
+        }
+    }
+}
+
+pub fn excel_free(xloper: LPXLOPER12) -> i32 {
+	fetch_excel12_entry_pt();
+
+    unsafe {
+        if PEXCEL12 == 0 {
+            xlretFailed as i32
+        } else {
+            mem::transmute::<usize, EXCEL12PROC>(PEXCEL12)(xlFree as i32, 1, &xloper, ptr::null_mut())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 pub mod xlcall;
+pub mod entrypoint;
+pub mod variant;
+
+extern crate winapi;
+extern crate widestring;
 
 #[cfg(test)]
 mod tests {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -1,0 +1,217 @@
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+
+use std::{mem, fmt, slice};
+use xlcall::{XLOPER12, LPXLOPER12, xloper12__bindgen_ty_1, 
+    xltypeNil, xltypeInt, xltypeStr, xltypeErr, xltypeMissing, xltypeNum,
+    xlbitDLLFree, xlbitXLFree,
+    xlerrNull, xlerrDiv0, xlerrValue, xlerrRef, xlerrName, xlerrNum, xlerrNA, xlerrGettingData };
+use entrypoint::excel_free;
+
+const xltypeMask : u32 = !(xlbitDLLFree | xlbitXLFree);
+
+/// Variant is a wrapper around an XLOPER12. It can contain a string, i32 or f64, or a
+/// two dimensional of any mixture of these. Basically, it can contain anything that an
+/// Excel cell or array of cells can contain.
+pub struct Variant(XLOPER12);
+
+impl Variant {
+    /// Construct a variant containing nil. This is used in Excel to represent cells that have
+    /// nothing in them. It is also a sensible starting state for an uninitialized variant.
+    pub fn new() -> Variant {
+        Variant(XLOPER12 { xltype : xltypeNil, val: xloper12__bindgen_ty_1 { w: 0 } })
+    }
+
+    /// Construct a variant from an LPXLOPER12, for example supplied by Excel. The assumption
+    /// is that Excel continues to own the XLOPER12 and its lifetime is greater than that of
+    /// the Variant we construct here. For example, the LPXLOPER may be an argument to one
+    /// of our functions. We therefore do not want to own any of the data in this variant, so
+    /// we clear all ownership bits. This means we treat it as a kind of dynamic mut ref. 
+    pub fn from_xloper(xloper: LPXLOPER12) -> Variant {
+        let mut result = Variant(unsafe { *xloper });
+        result.0.xltype &= xltypeMask;    // no ownership bits
+        result
+    }
+
+    /// Construct a variant containing an int (i32)
+    pub fn from_int(w: i32) -> Variant {
+        Variant(XLOPER12 { xltype : xltypeInt, val: xloper12__bindgen_ty_1 { w: w } })
+    }
+
+    /// Construct a variant containing a float (f64)
+    pub fn from_float(num: f64) -> Variant {
+        Variant(XLOPER12 { xltype : xltypeNum, val: xloper12__bindgen_ty_1 { num: num } })
+    }
+
+    /// Construct a variant containing a missing entry. This is used in function calls to
+    /// signal that a parameter should be defaulted.
+    pub fn missing() -> Variant {
+        Variant(XLOPER12 { xltype : xltypeMissing, val: xloper12__bindgen_ty_1 { w: 0 } })
+    }
+
+    /// Construct a variant containing an error. This is used in Excel to represent standard errors
+    /// that are shown as #DIV0 etc. Currently supported error codes are:
+    /// xlerrNull, xlerrDiv0, xlerrValue, xlerrRef, xlerrName, xlerrNum, xlerrNA, xlerrGettingData
+    pub fn from_err(xlerr: u32) -> Variant {
+        Variant(XLOPER12 { xltype : xltypeErr, val: xloper12__bindgen_ty_1 { err: xlerr as i32 } })
+    }
+
+    /// Construct a variant containing a string. Strings in Excel (at least after Excel 97) are 16bit
+    /// Unicode starting with a 16-bit length. The length is treated as signed, which means that
+    /// strings can be no longer than 32k characters. If a string longer than this is supplied, or a 
+    /// string that is not valid 16bit Unicode, an xlerrValue error is stored instead.
+    pub fn from_str(s: &str) -> Variant {
+        let mut wstr : Vec<u16> = s.encode_utf16().collect();
+        let len = wstr.len();
+        if len > 32767 {
+            return Variant::from_err(xlerrValue)
+        }
+
+        // Pascal-style string with length at the start. Forget the string so we do not delete it.
+        // We are now relying on the drop method of Variant to clean it up for us. Note that the
+        // shrink_to_fit is essential, so the capacity is the same as the length. We have no way
+        // of storing the capacity otherwise.
+        wstr.insert(0, len as u16);
+        wstr.shrink_to_fit();
+        let p = wstr.as_mut_ptr();
+        mem::forget(wstr);
+  
+        Variant(XLOPER12 { xltype : xltypeStr + xlbitDLLFree, val: xloper12__bindgen_ty_1 { str: p } })
+    }
+
+    /// Converts this variant to a string. Alternatively, you can use Display or to_string,
+    /// which both go through this call if the variant contains a string. Guaranteed to return
+    /// Some(...) if this object is of type xltypeStr. Always returns None if this object is
+    /// of any other type. If the string contains a unicode string that is misformed, return
+    /// the error message.
+    pub fn as_string(&self) -> Option<String> {
+        if (self.0.xltype & xltypeMask) != xltypeStr {
+             None
+        } else {
+            let cstr_slice = unsafe {
+                let cstr: *const u16 = self.0.val.str;
+                let cstr_len = *cstr.offset(0) as usize;
+                slice::from_raw_parts(cstr.offset(1), cstr_len) };
+            match String::from_utf16(cstr_slice) {
+                Ok(s) => Some(s),
+                Err(e) => Some(e.to_string())
+            }
+        }
+    }
+
+    /// Converts this variant to an int. If we do not contain an int, return None. Note that
+    /// Excel cells do not ever contain ints, so this would only come from a non-Excel user
+    /// creating an XLOPER, for example the result of a call into Excel.
+    pub fn as_i32(&self) -> Option<i32> {
+        if (self.0.xltype & xltypeMask) != xltypeInt {
+            None
+        } else {
+            Some(unsafe { self.0.val.w })
+        }
+    }
+    
+    /// Converts this variant to a float. If we do not contain a float, return None.
+    pub fn as_f64(&self) -> Option<f64> {
+        if (self.0.xltype & xltypeMask) != xltypeNum {
+            None
+        } else {
+            Some(unsafe { self.0.val.num })
+        }
+    }
+
+    /// Exposes the underlying XLOPER12
+    pub fn as_mut_xloper(&mut self) -> &mut XLOPER12 {
+        &mut self.0
+    }
+}
+
+/// Implement Display, which means we do not need a method for converting to strings. Just use
+/// to_string.
+impl fmt::Display for Variant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0.xltype & xltypeMask {
+            xltypeErr => match unsafe { self.0.val.err } as u32 {
+                xlerrNull => write!(f, "#NULL"),
+                xlerrDiv0 => write!(f, "#DIV0"),
+                xlerrValue => write!(f, "#VALUE"),
+                xlerrRef => write!(f, "#REF"),
+                xlerrName => write!(f, "#NAME"),
+                xlerrNum => write!(f, "#NUM"),
+                xlerrNA => write!(f, "#NA"),
+                xlerrGettingData => write!(f, "#DATA"),
+                _ => write!(f, "#BAD_ERR")
+            }
+            xltypeInt => write!(f, "{}", unsafe { self.0.val.w }),
+            xltypeMissing => write!(f, "#MISSING"),
+            xltypeNil => write!(f, "#NIL"),
+            xltypeNum => write!(f, "{}", unsafe { self.0.val.num }),
+            xltypeStr => write!(f, "{}", self.as_string().unwrap()),
+            _ => write!(f, "#BAD_XLOPER")
+        }
+    }
+}
+
+/// We need to implement Drop, as Variant is a wrapper around a union type that does
+/// not know how to handle its contained pointers.
+impl Drop for Variant {
+    fn drop(&mut self) {
+        if (self.0.xltype & xlbitXLFree) != 0 {
+            excel_free(&mut self.0);
+            return
+        }
+        match self.0.xltype {
+            xltypeStr | xlbitDLLFree => {
+                // We have a 16bit string that was originally allocated as a vector
+                // but then forgotten. Reconstruct the vector, so its drop method
+                // will clean up the memory for us.
+                unsafe {
+                    let p = self.0.val.str;
+                    let len = *p as usize;
+                    let cap = len;
+                    Vec::from_raw_parts(p, len, cap);
+                }
+            },
+            _ => {
+                // nothing to do
+                // TODO we need to handle arrays
+            }
+        }
+    }
+}
+
+/// We need to hand-code Clone, because of the ownership issues for strings and multi.
+impl Clone for Variant {
+    fn clone(&self) -> Variant {
+        // a simple copy is good enough for most variant types, but make sure the addin
+        // is the owner
+        let mut copy = Variant(self.0.clone());
+        copy.0.xltype &= !xlbitXLFree;
+        copy.0.xltype |= xlbitDLLFree;
+
+        // Special handling for string and mult, to avoid double delete of the member
+        match copy.0.xltype {
+            xltypeStr | xlbitDLLFree => {
+
+                // We have a 16bit string that was originally allocated as a vector
+                // but then forgotten. Reconstruct the vector, so we can clone it.
+                unsafe {
+                    let p = copy.0.val.str;
+                    let len = *p as usize;
+                    let cap = len;
+                    let string_vec = Vec::from_raw_parts(p, len, cap);
+                    let mut cloned = string_vec.clone();
+                    copy.0.val.str = cloned.as_mut_ptr();
+
+                    // now forget everything -- we do not want either string deallocated
+                    mem::forget(string_vec);
+                    mem::forget(cloned);
+                }
+            },
+            _ => {
+                // nothing to do
+                // TODO we need to handle arrays
+            }
+        }
+
+        copy
+    }
+}

--- a/src/xlcall.rs
+++ b/src/xlcall.rs
@@ -1054,8 +1054,8 @@ pub type HWND = *mut ::std::os::raw::c_void;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tagPOINT {
-    pub x: LONG,
-    pub y: LONG,
+    pub x: *mut ::std::os::raw::c_void,
+    pub y: *mut ::std::os::raw::c_void,
 }
 #[test]
 fn bindgen_test_layout_tagPOINT() {
@@ -2552,8 +2552,8 @@ pub type LPXLOPER12 = *mut xloper12;
 // The following code has been manually edited to correct the calling conventions, which
 // were all "C". Calls such as Excel4v and XLCallVer are actually specified as "pascal"
 // calling convention which is not currently supported by Rust. This is the same as "stdcall"
-// except that the parameters are passed left-to-right rather than right-to-left. We therefore
-// fake up Pascal calls by reversing the order of the parameters.
+// except that the parameters claim at be passed left-to-right rather than right-to-left.
+// This appears not to be the case, so we therefore leave the parameter order alone.
 
 extern "cdecl" {
     #[link_name = "\u{1}_Excel4"]
@@ -2567,10 +2567,10 @@ extern "cdecl" {
 extern "stdcall" /*pascal*/ {
     #[link_name = "\u{1}EXCEL4V"]
     pub fn Excel4v(
-        opers: *mut LPXLOPER,
-        count: ::std::os::raw::c_int,
-        operRes: LPXLOPER,
         xlfn: ::std::os::raw::c_int,
+        operRes: LPXLOPER,
+        count: ::std::os::raw::c_int,
+        opers: *mut LPXLOPER,
     ) -> ::std::os::raw::c_int;
 }
 extern "stdcall" /*pascal*/ {
@@ -2580,8 +2580,8 @@ extern "stdcall" /*pascal*/ {
 extern "stdcall" /*pascal*/ {
     #[link_name = "\u{1}LPENHELPER"]
     pub fn LPenHelper(
-        lpv: *mut VOID,
         wCode: ::std::os::raw::c_int, 
+        lpv: *mut VOID,
     ) -> ::std::os::raw::c_long;
 }
 extern "cdecl" {
@@ -2596,10 +2596,10 @@ extern "cdecl" {
 extern "stdcall" /*pascal*/ {
     #[link_name = "\u{1}EXCEL12V"]
     pub fn Excel12v(
-        opers: *mut LPXLOPER12,
-        count: ::std::os::raw::c_int,
-        operRes: LPXLOPER12,
         xlfn: ::std::os::raw::c_int,
+        operRes: LPXLOPER12,
+        count: ::std::os::raw::c_int,
+        opers: *mut LPXLOPER12,
     ) -> ::std::os::raw::c_int;
 }
 pub type PXL_HPC_ASYNC_CALLBACK = ::std::option::Option<

--- a/xlcall_modified.h
+++ b/xlcall_modified.h
@@ -30,7 +30,7 @@ typedef char* LPSTR;
 typedef void VOID;
 typedef void* HANDLE;
 typedef void* HWND;
-typedef struct tagPOINT { LONG x; LONG y; } POINT;
+typedef struct tagPOINT { void* x; void* y; } POINT;
 
 /*
 ** XL 12 Basic Datatypes 


### PR DESCRIPTION
No changes to functionality, but make everything safer and more pleasant. Created Variant class to wrap an XLOPER12 so we can localise all the unsafe code in one place. Stop the memory leaks and the usage of statics for returned objects. Also move as much code as we can from xladd-util to xladd.